### PR TITLE
Build and run any available tests on Travis-CI per commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly


### PR DESCRIPTION
By adding CI early, we get better feedback on PRs and, with good code coverage, can have relatively high confidence about the safety of changes being made.
