### PR TITLE
Fix build with latest stable channel Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 authors = ["Nathan Hoad <nathan@getoffmalawn.com>"]
 
 [dependencies]
-httparse = "1.1.2"
-mioco = "^0.5.0"
+httparse = "1.2.1"
+mioco = "^0.8.1"
 
 [dependencies.url]
 git = "https://github.com/servo/rust-url"
-

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -42,17 +42,16 @@ impl Client {
 
     pub fn connect(&self, url: &url::Url) -> io::Result<mioco::tcp::TcpStream> {
         // FIXME: actual async DNS would be nice?
-        let addrs = try!(mioco::sync(|| -> io::Result<url::SocketAddrs> {
-            url.to_socket_addrs()
-        }));
-
-        for addr in addrs {
-            match mioco::tcp::TcpStream::connect(&addr) {
-                Ok(conn) => {
-                    return Ok(conn);
-                }
-                Err(_) => {
-                    continue;
+        for addrs in url.to_socket_addrs() {
+            // Extract std::net::SocketAddr for this set
+            for addr in addrs {
+                match mioco::tcp::TcpStream::connect(&addr) {
+                    Ok(conn) => {
+                        return Ok(conn);
+                    }
+                    Err(_) => {
+                        continue;
+                    }
                 }
             }
         }


### PR DESCRIPTION
I had to remove the `mioco::sync` for DNS resolution but otherwise everything is untouched.

Note that mioco is now abandoned so it may be worth investigating an alternative.